### PR TITLE
fix: enforce locale in model tests

### DIFF
--- a/dogdog_trivia_game/test/helpers/test_helper.dart
+++ b/dogdog_trivia_game/test/helpers/test_helper.dart
@@ -10,6 +10,7 @@ class TestHelper {
   static Widget createTestApp(
     Widget child, {
     List<ChangeNotifierProvider>? providers,
+    Locale locale = const Locale('en'),
   }) {
     Widget app = MaterialApp(
       localizationsDelegates: const [
@@ -19,6 +20,7 @@ class TestHelper {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [Locale('en'), Locale('de'), Locale('es')],
+      locale: locale,
       home: child,
     );
 
@@ -33,6 +35,7 @@ class TestHelper {
   static Widget createTestAppWithProgressService(
     Widget child, {
     ProgressService? progressService,
+    Locale locale = const Locale('en'),
   }) {
     final service = progressService ?? ProgressService();
 
@@ -41,11 +44,15 @@ class TestHelper {
       providers: [
         ChangeNotifierProvider<ProgressService>.value(value: service),
       ],
+      locale: locale,
     );
   }
 
   /// Creates a basic MaterialApp wrapper for simple widget tests
-  static Widget createBasicTestApp(Widget child) {
+  static Widget createBasicTestApp(
+    Widget child, {
+    Locale locale = const Locale('en'),
+  }) {
     return MaterialApp(
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -54,6 +61,7 @@ class TestHelper {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [Locale('en'), Locale('de'), Locale('es')],
+      locale: locale,
       home: Scaffold(body: child),
     );
   }

--- a/dogdog_trivia_game/test/models/achievement_test.dart
+++ b/dogdog_trivia_game/test/models/achievement_test.dart
@@ -3,8 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:dogdog_trivia_game/models/achievement.dart';
 import 'package:dogdog_trivia_game/models/enums.dart';
 import 'package:dogdog_trivia_game/utils/enum_extensions.dart';
-import 'package:dogdog_trivia_game/l10n/generated/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import '../helpers/test_helper.dart';
 
 void main() {
   group('Achievement', () {
@@ -25,19 +24,6 @@ void main() {
       );
     });
 
-    Widget createTestWidget({required Widget child}) {
-      return MaterialApp(
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [Locale('en'), Locale('de'), Locale('es')],
-        home: child,
-      );
-    }
-
     test('should create Achievement with all fields', () {
       expect(testAchievement.id, 'test_achievement');
       expect(testAchievement.name, 'Test Achievement');
@@ -51,8 +37,8 @@ void main() {
 
     testWidgets('should create Achievement from Rank', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               final achievement = Achievement.fromRank(Rank.pug);
 
@@ -71,6 +57,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });

--- a/dogdog_trivia_game/test/models/enums_test.dart
+++ b/dogdog_trivia_game/test/models/enums_test.dart
@@ -2,28 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dogdog_trivia_game/models/enums.dart';
 import 'package:dogdog_trivia_game/utils/enum_extensions.dart';
-import 'package:dogdog_trivia_game/l10n/generated/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import '../helpers/test_helper.dart';
 
 void main() {
-  Widget createTestWidget({required Widget child}) {
-    return MaterialApp(
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [Locale('en'), Locale('de'), Locale('es')],
-      home: child,
-    );
-  }
-
   group('Difficulty', () {
     testWidgets('should have correct display names in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(Difficulty.easy.displayName(context), 'Leicht');
               expect(Difficulty.medium.displayName(context), 'Mittel');
@@ -32,6 +18,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });
@@ -55,8 +42,8 @@ void main() {
   group('PowerUpType', () {
     testWidgets('should have correct display names in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(PowerUpType.fiftyFifty.displayName(context), 'Chew 50/50');
               expect(PowerUpType.hint.displayName(context), 'Hinweis');
@@ -69,14 +56,15 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });
 
     testWidgets('should have descriptions in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(
                 PowerUpType.fiftyFifty.description(context),
@@ -101,6 +89,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });
@@ -118,8 +107,8 @@ void main() {
   group('Rank', () {
     testWidgets('should have correct display names in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(Rank.chihuahua.displayName(context), 'Chihuahua');
               expect(Rank.pug.displayName(context), 'Mops');
@@ -132,6 +121,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });
@@ -146,8 +136,8 @@ void main() {
 
     testWidgets('should have descriptions in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(
                 Rank.chihuahua.description(context),
@@ -172,6 +162,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });
@@ -199,8 +190,8 @@ void main() {
   group('GameResult', () {
     testWidgets('should have correct display names in German', (tester) async {
       await tester.pumpWidget(
-        createTestWidget(
-          child: Builder(
+        TestHelper.createTestApp(
+          Builder(
             builder: (context) {
               expect(GameResult.win.displayName(context), 'Gewonnen');
               expect(GameResult.lose.displayName(context), 'Verloren');
@@ -208,6 +199,7 @@ void main() {
               return Container();
             },
           ),
+          locale: const Locale('de'),
         ),
       );
     });


### PR DESCRIPTION
## Summary
- allow specifying locale in TestHelper utilities
- ensure model tests run with German translations by using the new locale option

## Testing
- `./scripts/run_tests.sh` *(fails: Flutter is not installed or not in PATH)*
- `flutter test test/models/enums_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68934f3fc5f883208e9d89c3759ff871